### PR TITLE
Add #nopage support

### DIFF
--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -1,11 +1,12 @@
 HttpClient = require 'scoped-http-client'
+Scrolls    = require('../../../lib/scrolls').context({script: 'pagerduty'})
 
 pagerDutyApiKey        = process.env.HUBOT_PAGERDUTY_API_KEY
 pagerDutySubdomain     = process.env.HUBOT_PAGERDUTY_SUBDOMAIN
 pagerDutyBaseUrl       = "https://#{pagerDutySubdomain}.pagerduty.com/api/v1"
 pagerDutyServices      = process.env.HUBOT_PAGERDUTY_SERVICES
 pagerNoop              = process.env.HUBOT_PAGERDUTY_NOOP
-pagerNoop               = false if pagerNoop is "false" or pagerNoop  is "off"
+pagerNoop              = false if pagerNoop is "false" or pagerNoop  is "off"
 
 class PagerDutyError extends Error
 module.exports =
@@ -31,12 +32,18 @@ module.exports =
     if pagerDutyServices? && url.match /\/incidents/
       query['service'] = pagerDutyServices
 
+    Scrolls.log('info', {at: 'get/request', url: url, query: query})
+
     @http(url)
       .query(query)
       .get() (err, res, body) ->
         if err?
+          Scrolls.log('info', {at: 'get/response', url: url, query: query, error: err})
           cb(err)
           return
+
+        Scrolls.log('info', {at: 'get/response', url: url, query: query, status: res.statusCode})
+
         json_body = null
         switch res.statusCode
           when 200 then json_body = JSON.parse(body)

--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -38,11 +38,11 @@ module.exports =
       .query(query)
       .get() (err, res, body) ->
         if err?
-          Scrolls.log('info', {at: 'get/response', url: url, query: query, error: err})
+          Scrolls.log('info', {at: 'get/error', url: url, query: query, error: err})
           cb(err)
           return
 
-        Scrolls.log('info', {at: 'get/response', url: url, query: query, status: res.statusCode})
+        Scrolls.log('info', {at: 'get/response', url: url, query: query, status: res.statusCode, body: body})
 
         unless res.statusCode is 200
           cb(new PagerDutyError("#{res.statusCode} back from #{url}"))

--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -10,6 +10,8 @@ pagerNoop              = false if pagerNoop is "false" or pagerNoop  is "off"
 
 class PagerDutyError extends Error
 module.exports =
+  subdomain: pagerDutySubdomain
+
   http: (path) ->
     HttpClient.create("#{pagerDutyBaseUrl}#{path}")
       .headers(Authorization: "Token token=#{pagerDutyApiKey}", Accept: 'application/json')

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -561,7 +561,7 @@ module.exports = (robot) ->
 
     renderSchedule = (s, cb) ->
       withCurrentOncall msg, s, (username, schedule) ->
-        Scrolls.log("info", {at: 'who-is-on-call/renderSchedule', schedule: s.name, username: username})
+        Scrolls.log("info", {at: 'who-is-on-call/renderSchedule', schedule: schedule.name, username: username})
         paging = if pagerEnabledForScheduleOrEscalation(schedule) then "enabled" else "disabled"
         cb null, "* #{username} is on call for #{schedule.name} (pager is #{paging}) - https://#{pagerduty.domain}.pagerduty.com/schedules##{schedule.id}"
 

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -41,6 +41,7 @@ pagerduty = require('../pagerduty')
 async = require('async')
 inspect = require('util').inspect
 moment = require('moment-timezone')
+Scrolls = require('../../../../lib/scrolls').context({script: 'pagerduty'})
 
 pagerDutyUserId        = process.env.HUBOT_PAGERDUTY_USER_ID
 pagerDutyServiceApiKey = process.env.HUBOT_PAGERDUTY_SERVICE_API_KEY
@@ -560,7 +561,8 @@ module.exports = (robot) ->
 
     renderSchedule = (s, cb) ->
       withCurrentOncall msg, s, (username, schedule) ->
-        paging = if pagerEnabledForScheduleOrEscalation(s) then "enabled" else "disabled"
+        Scrolls.log("info", {at: 'who-is-on-call/renderSchedule', schedule: s.name, username: username})
+        paging = if pagerEnabledForScheduleOrEscalation(schedule) then "enabled" else "disabled"
         cb null, "* #{username} is on call for #{schedule.name} (pager is #{paging}) - https://#{pagerduty.domain}.pagerduty.com/schedules##{schedule.id}"
 
     if scheduleName?

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -191,7 +191,7 @@ module.exports = (robot) ->
 
     force = msg.match[4]?
 
-    pagerduty.getIncidents 'triggered,acknwowledged', (err, incidents) ->
+    pagerduty.getIncidents 'triggered,acknowledged', (err, incidents) ->
       if err?
         robot.emit 'error', err, msg
         return

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -424,6 +424,8 @@ module.exports = (robot) ->
                   endTime   = moment(entry.end).tz(timezone).format()
 
                   buffer += "* #{startTime} - #{endTime} #{entry.user.name} (#{schedule.name})"
+            else
+              buffer = "couldn't get entries for #{schedule.name}"
 
             cb(null, buffer)
 

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -641,7 +641,7 @@ module.exports = (robot) ->
   #
   # Returns a Boolean instance.
   pagerEnabledForScheduleOrEscalation = (s) ->
-    s.description.indexOf('#nopage') is -1
+    (s.description or "").indexOf('#nopage') is -1
 
   parseIncidentNumbers = (match) ->
     match.split(/[ ,]+/).map (incidentNumber) ->

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -581,8 +581,10 @@ module.exports = (robot) ->
         if schedules.length > 0
           async.map schedules, renderSchedule, (err, results) ->
             if err?
+              Scrolls.log("error", {at: 'who-is-on-call/map-schedules', error: err})
               robot.emit 'error', err, msg
               return
+            Scrolls.log("info", {at: 'who-is-on-call/map-schedules'})
             msg.send results.join("\n")
         else
           msg.send 'No schedules found!'

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -92,18 +92,19 @@ module.exports = (robot) ->
         robot.emit 'error', err, msg
         return
 
-      if incidents.length > 0
-        buffer = "Triggered:\n----------\n"
-        for junk, incident of incidents.reverse()
-          if incident.status == 'triggered'
-            buffer = buffer + formatIncident(incident)
-        buffer = buffer + "\nAcknowledged:\n-------------\n"
-        for junk, incident of incidents.reverse()
-          if incident.status == 'acknowledged'
-            buffer = buffer + formatIncident(incident)
-        msg.send buffer
-      else
+      if incidents.length == 0
         msg.send "No open incidents"
+        return
+
+      buffer = "Triggered:\n----------\n"
+      for junk, incident of incidents.reverse()
+        if incident.status == 'triggered'
+          buffer = buffer + formatIncident(incident)
+      buffer = buffer + "\nAcknowledged:\n-------------\n"
+      for junk, incident of incidents.reverse()
+        if incident.status == 'acknowledged'
+          buffer = buffer + formatIncident(incident)
+      msg.send buffer
 
   robot.respond /(pager|major)( me)? (?:trigger|page) ([\w\-]+)$/i, (msg) ->
     msg.reply "Please include a user or schedule to page, like 'hubot pager infrastructure everything is on fire'."
@@ -149,26 +150,28 @@ module.exports = (robot) ->
 
               if json?.incidents.length == 0
                 msg.reply "Couldn't find the incident we just created to reassign. Please try again :/"
-              else
-                data = {
-                  requester_id: triggerdByPagerDutyUserId,
-                  incidents: json.incidents.map (incident) ->
-                    {
-                      id:                incident.id
-                      assigned_to_user:  results.assigned_to_user
-                      escalation_policy: results.escalation_policy
-                    }
-                }
+                return
 
-                pagerduty.put "/incidents", data , (err, json) ->
-                  if err?
-                    robot.emit 'error', err, msg
-                    return
+              data = {
+                requester_id: triggerdByPagerDutyUserId,
+                incidents: json.incidents.map (incident) ->
+                  {
+                    id:                incident.id
+                    assigned_to_user:  results.assigned_to_user
+                    escalation_policy: results.escalation_policy
+                  }
+              }
 
-                  if json?.incidents.length == 1
-                    msg.reply ":pager: assigned to #{results.name}!"
-                  else
-                    msg.reply "Problem reassigning the incident :/"
+              pagerduty.put "/incidents", data , (err, json) ->
+                if err?
+                  robot.emit 'error', err, msg
+                  return
+
+                if json?.incidents.length != 1
+                  msg.reply "Problem reassigning the incident :/"
+                  return
+
+                msg.reply ":pager: assigned to #{results.name}!"
           , 5000
 
   robot.respond /(?:pager|major)(?: me)? ack(?:nowledge)? (.+)$/i, (msg) ->
@@ -355,24 +358,25 @@ module.exports = (robot) ->
           return
 
         entries = json.entries || json.overrides
-        if entries
-          sortedEntries = entries.sort (a, b) ->
-            moment(a.start).unix() - moment(b.start).unix()
-
-          buffer = ""
-          for entry in sortedEntries
-            startTime = moment(entry.start).tz(timezone).format()
-            endTime   = moment(entry.end).tz(timezone).format()
-            if entry.id
-              buffer += "* (#{entry.id}) #{startTime} - #{endTime} #{entry.user.name}\n"
-            else
-              buffer += "* #{startTime} - #{endTime} #{entry.user.name}\n"
-          if buffer == ""
-            msg.send "None found!"
-          else
-            msg.send buffer
-        else
+        unless entries
           msg.send "None found!"
+          return
+
+        sortedEntries = entries.sort (a, b) ->
+          moment(a.start).unix() - moment(b.start).unix()
+
+        buffer = ""
+        for entry in sortedEntries
+          startTime = moment(entry.start).tz(timezone).format()
+          endTime   = moment(entry.end).tz(timezone).format()
+          if entry.id
+            buffer += "* (#{entry.id}) #{startTime} - #{endTime} #{entry.user.name}\n"
+          else
+            buffer += "* #{startTime} - #{endTime} #{entry.user.name}\n"
+        if buffer == ""
+          msg.send "None found!"
+        else
+          msg.send buffer
 
   robot.respond /(pager|major)( me)? my schedule( ([^ ]+))?$/i, (msg) ->
     if pagerduty.missingEnvironmentForApi(msg)
@@ -397,35 +401,37 @@ module.exports = (robot) ->
           robot.emit 'error', err, msg
           return
 
-        if schedules.length > 0
-          renderSchedule = (schedule, cb) ->
-            pagerduty.get "/schedules/#{schedule.id}/entries", query, (err, json) ->
-              if err?
-                cb(err)
-
-              entries = json.entries
-
-              if entries
-                sortedEntries = entries.sort (a, b) ->
-                  moment(a.start).unix() - moment(b.start).unix()
-
-                buffer = ""
-                for entry in sortedEntries
-                  if userId == entry.user.id
-                    startTime = moment(entry.start).tz(timezone).format()
-                    endTime   = moment(entry.end).tz(timezone).format()
-
-                    buffer += "* #{startTime} - #{endTime} #{entry.user.name} (#{schedule.name})\n"
-                cb(null, buffer)
-
-          async.map schedules, renderSchedule, (err, results) ->
-            if err?
-              robot.emit 'error', err, msg
-              return
-            msg.send results.join("")
-
-        else
+        if schedules.length == 0
           msg.send 'No schedules found!'
+          return
+
+        renderSchedule = (schedule, cb) ->
+          pagerduty.get "/schedules/#{schedule.id}/entries", query, (err, json) ->
+            if err?
+              cb(err)
+              return
+
+            buffer = ""
+
+            entries = json.entries
+            if entries
+              sortedEntries = entries.sort (a, b) ->
+                moment(a.start).unix() - moment(b.start).unix()
+
+              for entry in sortedEntries
+                if userId == entry.user.id
+                  startTime = moment(entry.start).tz(timezone).format()
+                  endTime   = moment(entry.end).tz(timezone).format()
+
+                  buffer += "* #{startTime} - #{endTime} #{entry.user.name} (#{schedule.name})"
+
+            cb(null, buffer)
+
+        async.map schedules, renderSchedule, (err, results) ->
+          if err?
+            robot.emit 'error', err, msg
+            return
+          msg.send results.join("\n")
 
   robot.respond /(pager|major)( me)? (override) ([\w\-]+) ([\w\-:\+]+) - ([\w\-:\+]+)( (.*))?$/i, (msg) ->
     if pagerduty.missingEnvironmentForApi(msg)
@@ -442,35 +448,39 @@ module.exports = (robot) ->
 
     campfireUserToPagerDutyUser msg, overrideUser, (user) ->
       userId = user.id
-      return unless userId
+      unless userId
+        return
 
       withScheduleMatching msg, msg.match[4], (schedule) ->
         scheduleId = schedule.id
-        return unless scheduleId
+        unless scheduleId
+          return
 
-        if moment(msg.match[5]).isValid() && moment(msg.match[6]).isValid()
-          start_time = moment(msg.match[5]).format()
-          end_time = moment(msg.match[6]).format()
-
-          override  = {
-            'start':     start_time,
-            'end':       end_time,
-            'user_id':   userId
-          }
-          data = { 'override': override }
-          pagerduty.post "/schedules/#{scheduleId}/overrides", data, (err, json) ->
-            if err?
-              robot.emit 'error', err, msg
-              return
-
-            if json && json.override
-              start = moment(json.override.start)
-              end = moment(json.override.end)
-              msg.send "Override setup! #{json.override.user.name} has the pager from #{start.format()} until #{end.format()}"
-            else
-              msg.send "That didn't work. Check Hubot's logs for an error!"
-        else
+        unless moment(msg.match[5]).isValid() && moment(msg.match[6]).isValid()
           msg.send "Please use a http://momentjs.com/ compatible date!"
+          return
+
+        start_time = moment(msg.match[5]).format()
+        end_time = moment(msg.match[6]).format()
+
+        override  = {
+          'start':     start_time,
+          'end':       end_time,
+          'user_id':   userId
+        }
+        data = { 'override': override }
+        pagerduty.post "/schedules/#{scheduleId}/overrides", data, (err, json) ->
+          if err?
+            robot.emit 'error', err, msg
+            return
+
+          unless json && json.override
+            msg.send "That didn't work. Check Hubot's logs for an error!"
+            return
+
+          start = moment(json.override.start)
+          end = moment(json.override.end)
+          msg.send "Override setup! #{json.override.user.name} has the pager from #{start.format()} until #{end.format()}"
 
   robot.respond /(pager|major)( me)? (overrides?) ([\w\-]*) (delete) (.*)$/i, (msg) ->
     if pagerduty.missingEnvironmentForApi(msg)
@@ -478,13 +488,15 @@ module.exports = (robot) ->
 
     withScheduleMatching msg, msg.match[4], (schedule) ->
       scheduleId = schedule.id
-      return unless scheduleId
+      unless scheduleId
+        return
 
       pagerduty.delete "/schedules/#{scheduleId}/overrides/#{msg.match[6]}", (err, success) ->
-        if success
-          msg.send ":boom:"
-        else
+        unless success
           msg.send "Something went weird."
+          return
+
+        msg.send ":boom:"
 
   robot.respond /pager( me)? (.+) (\d+)$/i, (msg) ->
     msg.finish()
@@ -495,15 +507,16 @@ module.exports = (robot) ->
     campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
 
       userId = user.id
-      return unless userId
+      unless userId
+        return
 
       if !msg.match[2] || msg.match[2] == 'me'
         msg.reply "Please specify a schedule with 'pager me infrastructure 60'. Use 'pager schedules' to list all schedules."
         return
 
       withScheduleMatching msg, msg.match[2], (matchingSchedule) ->
-
-        return unless matchingSchedule.id
+        unless matchingSchedule.id
+          return
 
         start     = moment().format()
         minutes   = parseInt msg.match[3]
@@ -520,10 +533,13 @@ module.exports = (robot) ->
               robot.emit 'error', err, msg
               return
 
-            if json.override
-              start = moment(json.override.start)
-              end = moment(json.override.end)
-              msg.send "Rejoice, #{old_username}! #{json.override.user.name} has the pager on #{schedule.name} until #{end.format()}"
+            unless json.override
+              msg.send "Something went weird."
+              return
+
+            start = moment(json.override.start)
+            end = moment(json.override.end)
+            msg.send "Rejoice, #{old_username}! #{json.override.user.name} has the pager on #{schedule.name} until #{end.format()}"
 
   # Am I on call?
   robot.respond /am i on (call|oncall|on-call)/i, (msg) ->
@@ -540,22 +556,24 @@ module.exports = (robot) ->
           else
             cb null, "* No, you are NOT on call for #{schedule.name} (but #{oncallUsername} is)- https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}"
 
-      if !userId?
+      unless userId?
         msg.send "Couldn't figure out the pagerduty user connected to your account."
-      else
-        pagerduty.getSchedules (err, schedules) ->
+        return
+
+      pagerduty.getSchedules (err, schedules) ->
+        if err?
+          robot.emit 'error', err, msg
+          return
+
+        if schedules.length == 0
+          msg.send 'No schedules found!'
+          return
+
+        async.map schedules, renderSchedule, (err, results) ->
           if err?
             robot.emit 'error', err, msg
             return
-
-          if schedules.length > 0
-            async.map schedules, renderSchedule, (err, results) ->
-              if err?
-                robot.emit 'error', err, msg
-                return
-              msg.send results.join("\n")
-          else
-            msg.send 'No schedules found!'
+          msg.send results.join("\n")
 
   # who is on call?
   robot.respond /who(’s|'s|s| is|se)? (on call|oncall|on-call)( (?:for )?(.+))?/i, (msg) ->
@@ -577,22 +595,24 @@ module.exports = (robot) ->
             robot.emit 'error'
             return
           msg.send text
-    else
-      pagerduty.getSchedules (err, schedules) ->
+      return
+
+    pagerduty.getSchedules (err, schedules) ->
+      if err?
+        robot.emit 'error', err, msg
+        return
+
+      if schedules.length == 0
+        msg.send 'No schedules found!'
+        return
+
+      async.map schedules, renderSchedule, (err, results) ->
         if err?
+          Scrolls.log("error", {at: 'who-is-on-call/map-schedules/error', error: err})
           robot.emit 'error', err, msg
           return
-
-        if schedules.length > 0
-          async.map schedules, renderSchedule, (err, results) ->
-            if err?
-              Scrolls.log("error", {at: 'who-is-on-call/map-schedules/error', error: err})
-              robot.emit 'error', err, msg
-              return
-            Scrolls.log("info", {at: 'who-is-on-call/map-schedules'})
-            msg.send results.join("\n")
-        else
-          msg.send 'No schedules found!'
+        Scrolls.log("info", {at: 'who-is-on-call/map-schedules'})
+        msg.send results.join("\n")
 
   robot.respond /(pager|major)( me)? services$/i, (msg) ->
     if pagerduty.missingEnvironmentForApi(msg)
@@ -603,14 +623,18 @@ module.exports = (robot) ->
         robot.emit 'error', err, msg
         return
 
-      buffer = ''
-      services = json.services
-      if services.length > 0
-        for service in services
-          buffer += "* #{service.id}: #{service.name} (#{service.status}) - https://#{pagerduty.subdomain}.pagerduty.com/services/#{service.id}\n"
-        msg.send buffer
-      else
+      if services.length == 0
         msg.send 'No services found!'
+        return
+
+      renderService = (service, cb) ->
+        cb(null, "* #{service.id}: #{service.name} (#{service.status}) - https://#{pagerduty.subdomain}.pagerduty.com/services/#{service.id}")
+
+      async.map json.services, renderService, (err, results) ->
+        if err?
+          robot.emit 'error', err, msg
+          return
+        msg.send results.join("\n")
 
   robot.respond /(pager|major)( me)? maintenance (\d+) (.+)$/i, (msg) ->
     if pagerduty.missingEnvironmentForApi(msg)
@@ -618,7 +642,8 @@ module.exports = (robot) ->
 
     campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
       requester_id = user.id
-      return unless requester_id
+      unless requester_id
+        return
 
       minutes = msg.match[3]
       service_ids = msg.match[4].split(' ')
@@ -638,10 +663,11 @@ module.exports = (robot) ->
           robot.emit 'error', err, msg
           return
 
-        if json && json.maintenance_window
-          msg.send "Maintenance window created! ID: #{json.maintenance_window.id} Ends: #{json.maintenance_window.end_time}"
-        else
+        unless json && json.maintenance_window
           msg.send "That didn't work. Check Hubot's logs for an error!"
+          return
+
+        msg.send "Maintenance window created! ID: #{json.maintenance_window.id} Ends: #{json.maintenance_window.end_time}"
 
   # Determine whether a schedule's participants are available to be paged.
   #
@@ -650,14 +676,14 @@ module.exports = (robot) ->
   #
   # Returns a Boolean instance.
   pagerEnabledForScheduleOrEscalation = (s) ->
-    (s.description or "").indexOf('#nopage') is -1
+    description = s.description or ""
+    return description.indexOf('#nopage') == -1
 
   parseIncidentNumbers = (match) ->
     match.split(/[ ,]+/).map (incidentNumber) ->
       parseInt(incidentNumber)
 
   campfireUserToPagerDutyUser = (msg, user, required, cb) ->
-
     if typeof required is 'function'
       cb = required
       required = true
@@ -839,9 +865,9 @@ module.exports = (robot) ->
 
   updateIncidents = (msg, incidentNumbers, statusFilter, updatedStatus) ->
     campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
-
       requesterId = user.id
-      return unless requesterId
+      unless requesterId
+        return
 
       pagerduty.getIncidents statusFilter, (err, incidents) ->
         if err?
@@ -872,16 +898,16 @@ module.exports = (robot) ->
               robot.emit 'error', err, msg
               return
 
-            if json?.incidents
-              buffer = "Incident"
-              buffer += "s" if json.incidents.length > 1
-              buffer += " "
-              buffer += (incident.incident_number for incident in json.incidents).join(", ")
-              buffer += " #{updatedStatus}"
-              msg.reply buffer
-            else
+            unless json?.incidents
               msg.reply "Problem updating incidents #{incidentNumbers.join(',')}"
+              return
 
+            buffer = "Incident"
+            buffer += "s" if json.incidents.length > 1
+            buffer += " "
+            buffer += (incident.incident_number for incident in json.incidents).join(", ")
+            buffer += " #{updatedStatus}"
+            msg.reply buffer
 
   pagerDutyIntegrationPost = (msg, json, cb) ->
     msg.http('https://events.pagerduty.com/generic/2010-04-15/create_event.json')

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -560,7 +560,8 @@ module.exports = (robot) ->
 
     renderSchedule = (s, cb) ->
       withCurrentOncall msg, s, (username, schedule) ->
-        cb null, "* #{username} is on call for #{schedule.name} - https://#{pagerduty.domain}.pagerduty.com/schedules##{schedule.id}"
+        paging = if pagerEnabledForSchedule(s) then "enabled" else "disabled"
+        cb null, "* #{username} is on call for #{schedule.name} (pager is #{paging}) - https://#{pagerduty.domain}.pagerduty.com/schedules##{schedule.id}"
 
     if scheduleName?
       withScheduleMatching msg, scheduleName, (s) ->
@@ -632,6 +633,15 @@ module.exports = (robot) ->
           msg.send "Maintenance window created! ID: #{json.maintenance_window.id} Ends: #{json.maintenance_window.end_time}"
         else
           msg.send "That didn't work. Check Hubot's logs for an error!"
+
+  # Determine whether a schedule's participants are available to be paged.
+  #
+  # s :: Object
+  #      Decoded JSON from the Pagerduty Schedules API.
+  #
+  # Returns a Boolean instance.
+  pagerEnabledForSchedule = (s) ->
+    schedule.description.indexOf('#nopage') is -1
 
   parseIncidentNumbers = (match) ->
     match.split(/[ ,]+/).map (incidentNumber) ->

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -739,7 +739,7 @@ module.exports = (robot) ->
 
         if escalationPolicy?
           unless pagerEnabledForScheduleOrEscalation(escalationPolicy)
-            error = new Error("Found the #{escalationPolicy.name} escalation policy but it is marked #nopage, please page another escalation policy.")
+            error = new Error("Found the #{escalationPolicy.name} escalation policy but it is marked #nopage, see /who's on call for schedules you can page.")
             cb(error, null)
             return
 
@@ -749,7 +749,7 @@ module.exports = (robot) ->
         oneScheduleMatching msg, string, (schedule) ->
           if schedule
             unless pagerEnabledForScheduleOrEscalation(schedule)
-              error = new Error("Found the #{schedule.name} schedule but it is marked #nopage, please page another schedule.")
+              error = new Error("Found the #{schedule.name} schedule but it is marked #nopage, see /who's on call for schedules you can page.")
               cb(error, null)
               return
 
@@ -758,7 +758,7 @@ module.exports = (robot) ->
 
             return
 
-          error = new Error("Couldn't find a user or unique schedule or escalation policy matching #{string} :/")
+          error = new Error("Couldn't find a user, unique schedule or escalation policy matching #{string} to page, see /who's on call for schedules you can page.")
           cb(error, null)
 
   withCurrentOncall = (msg, schedule, cb) ->

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -563,7 +563,7 @@ module.exports = (robot) ->
       withCurrentOncall msg, s, (username, schedule) ->
         Scrolls.log("info", {at: 'who-is-on-call/renderSchedule', schedule: schedule.name, username: username})
         paging = if pagerEnabledForScheduleOrEscalation(schedule) then "enabled" else "disabled"
-        cb(null, "* #{username} is on call for #{schedule.name} (pager is #{paging}) - https://#{pagerduty.domain}.pagerduty.com/schedules##{schedule.id}")
+        cb(null, "* #{username} is on call for #{schedule.name} (pager is #{paging}) - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}")
 
     if scheduleName?
       withScheduleMatching msg, scheduleName, (s) ->

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -560,7 +560,7 @@ module.exports = (robot) ->
 
     renderSchedule = (s, cb) ->
       withCurrentOncall msg, s, (username, schedule) ->
-        paging = if pagerEnabledForSchedule(s) then "enabled" else "disabled"
+        paging = if pagerEnabledForScheduleOrEscalation(s) then "enabled" else "disabled"
         cb null, "* #{username} is on call for #{schedule.name} (pager is #{paging}) - https://#{pagerduty.domain}.pagerduty.com/schedules##{schedule.id}"
 
     if scheduleName?
@@ -637,11 +637,11 @@ module.exports = (robot) ->
   # Determine whether a schedule's participants are available to be paged.
   #
   # s :: Object
-  #      Decoded JSON from the Pagerduty Schedules API.
+  #      Decoded JSON from the Pagerduty Schedules or Escalation API.
   #
   # Returns a Boolean instance.
-  pagerEnabledForSchedule = (s) ->
-    schedule.description.indexOf('#nopage') is -1
+  pagerEnabledForScheduleOrEscalation = (s) ->
+    s.description.indexOf('#nopage') is -1
 
   parseIncidentNumbers = (match) ->
     match.split(/[ ,]+/).map (incidentNumber) ->

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -563,7 +563,7 @@ module.exports = (robot) ->
       withCurrentOncall msg, s, (username, schedule) ->
         Scrolls.log("info", {at: 'who-is-on-call/renderSchedule', schedule: schedule.name, username: username})
         paging = if pagerEnabledForScheduleOrEscalation(schedule) then "enabled" else "disabled"
-        cb null, "* #{username} is on call for #{schedule.name} (pager is #{paging}) - https://#{pagerduty.domain}.pagerduty.com/schedules##{schedule.id}"
+        cb(null, "* #{username} is on call for #{schedule.name} (pager is #{paging}) - https://#{pagerduty.domain}.pagerduty.com/schedules##{schedule.id}")
 
     if scheduleName?
       withScheduleMatching msg, scheduleName, (s) ->
@@ -581,7 +581,7 @@ module.exports = (robot) ->
         if schedules.length > 0
           async.map schedules, renderSchedule, (err, results) ->
             if err?
-              Scrolls.log("error", {at: 'who-is-on-call/map-schedules', error: err})
+              Scrolls.log("error", {at: 'who-is-on-call/map-schedules/error', error: err})
               robot.emit 'error', err, msg
               return
             Scrolls.log("info", {at: 'who-is-on-call/map-schedules'})

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -845,7 +845,7 @@ module.exports = (robot) ->
         return
 
       unless json.entries and json.entries.length > 0
-        cb(new Error("no entries in #{schedule.id}"), null, null)
+        cb(null, "nobody", schedule)
         return
 
       cb(null, json.entries[0].user, schedule)


### PR DESCRIPTION
This adds support for people to mark their schedules and escalation policies as `#nopage` in the description field in Pagerduty to a) mark their schedule as non-pager expecting and b) prevent pages from being sent.