### PR TITLE
pagerduty: hide non-pageable schedules.

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -599,8 +599,9 @@ module.exports = (robot) ->
           return
 
         Scrolls.log("info", {at: 'who-is-on-call/renderSchedule', schedule: schedule.name, username: username})
-        paging = if pagerEnabledForScheduleOrEscalation(schedule) then "enabled" else "disabled"
-        cb(null, "* #{schedule.name}'s oncall is #{username} (pager is #{paging}) - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}")
+        return unless pagerEnabledForScheduleOrEscalation(schedule)
+        return if username == "hubot"
+        cb(null, "* #{schedule.name}'s oncall is #{username} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}")
 
     if scheduleName?
       withScheduleMatching msg, scheduleName, (s) ->

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -600,7 +600,9 @@ module.exports = (robot) ->
 
         Scrolls.log("info", {at: 'who-is-on-call/renderSchedule', schedule: schedule.name, username: username})
         if !pagerEnabledForScheduleOrEscalation(schedule) || username == "hubot"
-          return cb(null, undefined)
+          cb(null, undefined)
+          return
+
         cb(null, "* #{schedule.name}'s oncall is #{username} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}")
 
     if scheduleName?
@@ -626,8 +628,8 @@ module.exports = (robot) ->
           Scrolls.log("error", {at: 'who-is-on-call/map-schedules/error', error: err})
           robot.emit 'error', err, msg
           return
-        unless results?
-          return
+
+        results = (result for result in results when result?)
         Scrolls.log("info", {at: 'who-is-on-call/map-schedules'})
         msg.send results.join("\n")
 

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -599,8 +599,8 @@ module.exports = (robot) ->
           return
 
         Scrolls.log("info", {at: 'who-is-on-call/renderSchedule', schedule: schedule.name, username: username})
-        return unless pagerEnabledForScheduleOrEscalation(schedule)
-        return if username == "hubot"
+        if !pagerEnabledForScheduleOrEscalation(schedule) || username == "hubot"
+          return cb(null, undefined)
         cb(null, "* #{schedule.name}'s oncall is #{username} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}")
 
     if scheduleName?
@@ -625,6 +625,8 @@ module.exports = (robot) ->
         if err?
           Scrolls.log("error", {at: 'who-is-on-call/map-schedules/error', error: err})
           robot.emit 'error', err, msg
+          return
+        unless results?
           return
         Scrolls.log("info", {at: 'who-is-on-call/map-schedules'})
         msg.send results.join("\n")


### PR DESCRIPTION
`.who's on call`'s primary use-case is people trying to figure out who is on-call that should be paged for a schedule. As a result, `hubot` or a non-pageable schedule are noise in this case (but useful for every other command where e.g. users may wish to know if they are on-call for a non-pageable shift).

As a result, don't display a schedule if `hubot` is on call or the schedule has the pager disabled.

CC @keithduncan for review and thoughts.