### PR TITLE
Fix 'my schedule' output

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -436,7 +436,7 @@ module.exports = (robot) ->
                   startTime = moment(entry.start).tz(timezone).format()
                   endTime   = moment(entry.end).tz(timezone).format()
 
-                  buffer += "* #{startTime} - #{endTime} #{entry.user.name} (#{schedule.name})"
+                  buffer += "* #{startTime} - #{endTime} #{entry.user.name} (#{schedule.name})\n"
             else
               buffer = "couldn't get entries for #{schedule.name}"
 


### PR DESCRIPTION
Add a newline char after each entry. Right now it looks like 

![image](https://cloud.githubusercontent.com/assets/17516/25620299/3db74d5c-2f4e-11e7-9365-7bdf28bf521b.png)

cc @github/dx (I think you own this) and @bhuga based on preview review requests