### PR TITLE
Upgrade PagerDuty v2 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "async": "^1.4.2",
     "coffee-script": "~1.6",
     "moment-timezone": "~0.4.0",
-    "scoped-http-client": "^0.11.0"
+    "request": "^2.83.0",
+    "query-string": "^5.0.1"
   },
   "devDependencies": {
     "chai": "^2.1.1",

--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -64,11 +64,11 @@ module.exports =
       console.log "Would have PUT #{path}: #{inspect data}"
       return
 
-    Scrolls.log('info', {at: 'put/request', path: path, query: query, body: data})
+    Scrolls.log('info', {at: 'put/request', path: path, body: data})
 
     request.put {uri: @url(path), json: true, headers: @headers(customHeaders), body: data}, (err, res, body) ->
       if err?
-        Scrolls.log('info', {at: 'put/error', path: path, query: query, error: err})
+        Scrolls.log('info', {at: 'put/error', path: path, error: err})
         cb(err)
         return
 
@@ -85,11 +85,11 @@ module.exports =
       console.log "Would have POST #{path}: #{inspect data}"
       return  
     
-    Scrolls.log('info', {at: 'post/request', path: path, query: query, body: data})
+    Scrolls.log('info', {at: 'post/request', path: path, body: data})
 
     request.post {uri: @url(path), json: true, headers: @headers(customHeaders), body: data}, (err, res, body) ->
       if err?
-        Scrolls.log('info', {at: 'post/error', path: path, query: query, error: err})
+        Scrolls.log('info', {at: 'post/error', path: path, error: err})
         cb(err)
         return
 

--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -32,7 +32,7 @@ module.exports =
       query = {}
 
     if pagerDutyServices? && url.match /\/incidents/
-      query['service'] = pagerDutyServices
+      query['service_ids'] = pagerDutyServices.split ","
 
     Scrolls.log('info', {at: 'get/request', url: url, query: query})
 
@@ -52,7 +52,7 @@ module.exports =
 
         cb(null, JSON.parse(body))
 
-  put: (url, data, cb) ->
+  put: (url, data, cb = (->), headers = {}) ->
     if pagerNoop
       console.log "Would have PUT #{url}: #{inspect data}"
       return
@@ -61,6 +61,7 @@ module.exports =
     @http(url)
       .header("content-type","application/json")
       .header("content-length",json.length)
+      .headers(headers)
       .put(json) (err, res, body) ->
         if err?
           cb(err)
@@ -72,7 +73,7 @@ module.exports =
 
         cb(null, JSON.parse(body))
 
-  post: (url, data, cb) ->
+  post: (url, data, cb = (->), headers = {}) ->
     if pagerNoop
       console.log "Would have POST #{url}: #{inspect data}"
       return
@@ -81,6 +82,7 @@ module.exports =
     @http(url)
       .header("content-type","application/json")
       .header("content-length",json.length)
+      .headers(headers)
       .post(json) (err, res, body) ->
         if err?
           cb(err)
@@ -119,9 +121,9 @@ module.exports =
 
       cb(null, json)
 
-  getIncidents: (status, cb) ->
+  getIncidents: (statuses, cb) ->
     query =
-      status:  status
+      statuses:  statuses.split ","
       sort_by: "incident_number:asc"
     @get "/incidents", query, (err, json) ->
       if err?

--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -43,8 +43,6 @@ module.exports =
     if pagerDutyServices? && path.match /\/incidents/
       query['service_ids'] = pagerDutyServices.split ","
 
-    Scrolls.log('info', {at: 'get/request', path: path, query: query})
-
     request.get {uri: @url(path, query), json: true, headers: @headers()}, (err, res, body) ->
       if err?
         Scrolls.log('info', {at: 'get/error', path: path, query: query, error: err})
@@ -66,6 +64,7 @@ module.exports =
 
     request.put {uri: @url(path), json: true, headers: @headers(customHeaders), body: data}, (err, res, body) ->
       if err?
+        Scrolls.log('info', {at: 'put/error', path: path, query: query, error: err})
         cb(err)
         return
 
@@ -84,6 +83,7 @@ module.exports =
 
     request.post {uri: @url(path), json: true, headers: @headers(customHeaders), body: data}, (err, res, body) ->
       if err?
+        Scrolls.log('info', {at: 'post/error', path: path, query: query, error: err})
         cb(err)
         return
 
@@ -102,8 +102,11 @@ module.exports =
 
     request.delete {uri: @url(path), headers: @headers()}, (err, res) ->
       if err?
+        Scrolls.log('info', {at: 'delete/error', path: path, query: query, error: err})
         cb(err)
         return
+
+      Scrolls.log('info', {at: 'delete/response', path: path, status: res.statusCode})
 
       unless res.statusCode is 200 or res.statusCode is 204
         cb(new PagerDutyError("#{res.statusCode} back from #{path}"), false)

--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -43,6 +43,8 @@ module.exports =
     if pagerDutyServices? && path.match /\/incidents/
       query['service_ids'] = pagerDutyServices.split ","
 
+    Scrolls.log('info', {at: 'get/request', path: path, query: query})
+
     request.get {uri: @url(path, query), json: true, headers: @headers()}, (err, res, body) ->
       if err?
         Scrolls.log('info', {at: 'get/error', path: path, query: query, error: err})
@@ -62,6 +64,8 @@ module.exports =
       console.log "Would have PUT #{path}: #{inspect data}"
       return
 
+    Scrolls.log('info', {at: 'put/request', path: path, query: query, body: data})
+
     request.put {uri: @url(path), json: true, headers: @headers(customHeaders), body: data}, (err, res, body) ->
       if err?
         Scrolls.log('info', {at: 'put/error', path: path, query: query, error: err})
@@ -79,7 +83,9 @@ module.exports =
   post: (path, data, customHeaders, cb) ->
     if pagerNoop
       console.log "Would have POST #{path}: #{inspect data}"
-      return
+      return  
+    
+    Scrolls.log('info', {at: 'post/request', path: path, query: query, body: data})
 
     request.post {uri: @url(path), json: true, headers: @headers(customHeaders), body: data}, (err, res, body) ->
       if err?
@@ -99,6 +105,8 @@ module.exports =
     if pagerNoop
       console.log "Would have DELETE #{path}"
       return
+
+    Scrolls.log('info', {at: 'delete/request', path: path, query: query})
 
     request.delete {uri: @url(path), headers: @headers()}, (err, res) ->
       if err?

--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -1,5 +1,5 @@
 HttpClient = require 'scoped-http-client'
-Scrolls    = require('../../../lib/scrolls').context({script: 'pagerduty'})
+#Scrolls    = require('../../../lib/scrolls').context({script: 'pagerduty'})
 
 pagerDutyApiKey        = process.env.HUBOT_PAGERDUTY_API_KEY
 pagerDutySubdomain     = process.env.HUBOT_PAGERDUTY_SUBDOMAIN
@@ -34,7 +34,7 @@ module.exports =
     if pagerDutyServices? && url.match /\/incidents/
       query['service_ids'] = pagerDutyServices.split ","
 
-    Scrolls.log('info', {at: 'get/request', url: url, query: query})
+    #Scrolls.log('info', {at: 'get/request', url: url, query: query})
 
     @http(url)
       .query(query)
@@ -44,7 +44,7 @@ module.exports =
           cb(err)
           return
 
-        Scrolls.log('info', {at: 'get/response', url: url, query: query, status: res.statusCode, body: body})
+        #Scrolls.log('info', {at: 'get/response', url: url, query: query, status: res.statusCode, body: body})
 
         unless res.statusCode is 200
           cb(new PagerDutyError("#{res.statusCode} back from #{url}"))

--- a/src/scripts/pagerduty-webhook.coffee
+++ b/src/scripts/pagerduty-webhook.coffee
@@ -19,7 +19,7 @@ module.exports = (robot) ->
 
     messages = hook.messages
 
-    if /^incident.*$/.test(messages[0].type)
+    if /^incident.*$/.test(messages[0].event)
       parseIncidents(messages)
     else
       "No incidents in webhook"
@@ -28,20 +28,23 @@ module.exports = (robot) ->
     returnMessage = []
     count = 0
     for message in messages
-      incident = message.data.incident
-      hookType = message.type
+      incident = message.incident
+      hookType = message.event
       returnMessage.push(generateIncidentString(incident, hookType))
       count = count+1
     returnMessage.unshift("You have " + count + " PagerDuty update(s): \n")
     returnMessage.join("\n")
 
   getUserForIncident = (incident) ->
-    if incident.assigned_to_user
-      incident.assigned_to_user.email
-    else if incident.resolved_by_user
-      incident.resolved_by_user.email
-    else
-      '(???)'
+    users = []
+    for assigned in incident.assignments
+      if assigned.assignee.summary
+        users.push assigned.assignee.summary
+    
+    if users.length > 0
+      users.join ", "
+    else 
+      "(???)" 
 
   generateIncidentString = (incident, hookType) ->
     console.log "hookType is " + hookType

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -144,7 +144,13 @@ module.exports = (robot) ->
 
     # Figure out who we are
     campfireUserToPagerDutyUser msg, hubotUser, false, (triggeredByPagerDutyUser) ->
-      triggeredByPagerDutyUserEmail = emailForUser(triggeredByPagerDutyUser)
+      if triggerdByPagerDutyUser?
+        triggeredByPagerDutyUserEmail = emailForUser(triggeredByPagerDutyUser)
+      else
+        # if user who sent message does not have PD account, use hubot's
+        getPagerDutyUser pagerDutyUserId, (user) ->
+          triggeredByPagerDutyUserEmail = emailForUser(user)
+
       unless triggeredByPagerDutyUserEmail
         msg.send "Sorry, I can't figure your PagerDuty account, and I don't have my own :( Can you tell me your PagerDuty email with `#{robot.name} pager me as you@yourdomain.com`?"
         return

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -41,7 +41,7 @@ pagerduty = require('../pagerduty')
 async = require('async')
 inspect = require('util').inspect
 moment = require('moment-timezone')
-Scrolls = require('../../../../lib/scrolls').context({script: 'pagerduty'})
+#Scrolls = require('../../../../lib/scrolls').context({script: 'pagerduty'})
 
 pagerDutyUserId        = process.env.HUBOT_PAGERDUTY_USER_ID
 pagerDutyServiceApiKey = process.env.HUBOT_PAGERDUTY_SERVICE_API_KEY
@@ -645,7 +645,7 @@ module.exports = (robot) ->
           cb(err)
           return
 
-        Scrolls.log("info", {at: 'who-is-on-call/renderSchedule', schedule: schedule.name, username: username})
+        #Scrolls.log("info", {at: 'who-is-on-call/renderSchedule', schedule: schedule.name, username: username})
         if !pagerEnabledForScheduleOrEscalation(schedule) || username == "hubot"
           cb(null, undefined)
           return
@@ -672,12 +672,12 @@ module.exports = (robot) ->
 
       async.map schedules, renderSchedule, (err, results) ->
         if err?
-          Scrolls.log("error", {at: 'who-is-on-call/map-schedules/error', error: err})
+          #Scrolls.log("error", {at: 'who-is-on-call/map-schedules/error', error: err})
           robot.emit 'error', err, msg
           return
 
         results = (result for result in results when result?)
-        Scrolls.log("info", {at: 'who-is-on-call/map-schedules'})
+        #Scrolls.log("info", {at: 'who-is-on-call/map-schedules'})
         msg.send results.join("\n")
 
   # hubot pager services - list services


### PR DESCRIPTION
This PR moves us to the newer PagerDuty [v2 API](https://v2.developer.pagerduty.com/v2/page/api-reference), since v1 [reaches EOL in Feb 2018](https://v2.developer.pagerduty.com/v2/docs/api-v2-frequently-asked-questions#section-when-does-the-support-for-the-previous-api-version-end-).

Here is the checklist for completion:

- [x] Sync with Antonio to understand scope and context of problem (https://github.com/github/sre/issues/1016).
- [x] Understand how hubot-pager-me is currently deployed, e.g. what is the [Scrolls dep](https://github.com/github/hubot-pager-me/pull/1#discussion_r42968310), how are updates rolled out to the host?
- [x] Update HTTP calls.
- [x] Get `github-development`, `github-staging` and `github` PagerDuty accounts set up (need LastPass, so depends on https://github.com/github/security-iam/issues/330) for testing.
- [ ] Sync with SRE and DevEx folks so they are aware of updates and know where to file bugs if they appear.
- [ ] Once this PR is merged, submit a PR to github/hubot-classic to update the [pinned version](https://github.com/github/hubot-classic/blob/master/package.json#L45).

Corollary action items that are not essential now, but can possibly be added to our backlog:

- Are the hubot webhooks packaged under our recommended model? If not, is there opportunity to migrate?
- Can we upstream these v2 changes? If so, how much work to disentangle it from our private commits?
- Do we need a private fork?