### PR TITLE
Use pagination for collections

### DIFF
--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -1,5 +1,5 @@
 HttpClient = require 'scoped-http-client'
-#Scrolls    = require('../../../lib/scrolls').context({script: 'pagerduty'})
+Scrolls    = require('../../../lib/scrolls').context({script: 'pagerduty'})
 request    = require 'request'
 qs         = require 'query-string'
 

--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -1,5 +1,5 @@
 HttpClient = require 'scoped-http-client'
-Scrolls    = require('../../../lib/scrolls').context({script: 'pagerduty'})
+#Scrolls    = require('../../../lib/scrolls').context({script: 'pagerduty'})
 request    = require 'request'
 qs         = require 'query-string'
 
@@ -65,6 +65,8 @@ module.exports =
 
     if not query["offset"]
       query["offset"] = 0
+    if not query["limit"]
+      query["limit"] = 100
     
     cb = (err, body) ->
       if err?
@@ -168,9 +170,9 @@ module.exports =
       cb = query
       query = {}
 
-    @get "/schedules", query, (err, json) ->
+    @getAll "/schedules", query, "schedules", (err, schedules) ->
       if err?
         cb(err)
         return
 
-      cb(null, json.schedules)
+      cb(null, schedules)

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -42,7 +42,7 @@ async = require('async')
 inspect = require('util').inspect
 moment = require('moment-timezone')
 request = require 'request'
-#Scrolls = require('../../../../lib/scrolls').context({script: 'pagerduty'})
+Scrolls = require('../../../../lib/scrolls').context({script: 'pagerduty'})
 
 pagerDutyUserEmail     = process.env.HUBOT_PAGERDUTY_USERNAME
 pagerDutyServiceApiKey = process.env.HUBOT_PAGERDUTY_SERVICE_API_KEY

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -482,8 +482,6 @@ module.exports = (robot) ->
             scheduleId = oncall.schedule.id
             if scheduleId not of schedules 
               schedules[scheduleId] = []
-            console.log scheduleId
-            console.log schedules[scheduleId]
             if time not in schedules[scheduleId]
               schedules[scheduleId].push time
               buffer += "* #{time} #{user.name} (#{oncall.schedule.summary})\n"

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -473,11 +473,23 @@ module.exports = (robot) ->
           return
 
         buffer = ""
+        schedules = {}
         for oncall in oncalls 
           startTime = moment(oncall.start).tz(timezone).format()
           endTime   = moment(oncall.end).tz(timezone).format()
-          epSummary = oncall.escalation_policy.summary
-          buffer   += "* #{startTime} - #{endTime} #{user.name} (#{epSummary})\n"
+          time      = "#{startTime} - #{endTime}"
+          if oncall.schedule?
+            scheduleId = oncall.schedule.id
+            if scheduleId not of schedules 
+              schedules[scheduleId] = []
+            console.log scheduleId
+            console.log schedules[scheduleId]
+            if time not in schedules[scheduleId]
+              schedules[scheduleId].push time
+              buffer += "* #{time} #{user.name} (#{oncall.schedule.summary})\n"
+          else 
+            epSummary = oncall.escalation_policy.summary
+            buffer += "* #{time} #{user.name} (#{epSummary})\n"
         
         msg.send buffer
 


### PR DESCRIPTION
This PR does a few things:

- uses pagination for collections of resources
- refactors the "my schedule" call to be more performant. Instead of calling `/schedules` and then performing a `/oncalls` request per schedule it now uses a single API call (`/oncalls`) with URL query