### PR TITLE
Ignore schedules with 'hidden' in the name.

### DIFF
--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -175,4 +175,6 @@ module.exports =
         cb(err)
         return
 
+      schedules = schedules.filter (x) -> x.indexOf("hidden") == -1
+
       cb(null, schedules)

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -1,5 +1,5 @@
 # Description:
-#   Interact with PagerDuty services, schedules, and incidents with Hubot.
+#   Interact with PagerDuty services, schedules, and incidents with Hubot.  Schedules with "hidden" in the name will be ignored.
 #
 # Commands:
 #   hubot pager me as <email> - remember your pager email is <email>


### PR DESCRIPTION
In https://github.com/github/git-infrastructure/issues/480 it was pointed out that our PagerDuty acrobatics to achieve follow-the-sun on-call rotations had a side-effect of bloating the output of `.who's on call` with extra irrelevant schedules.

My preference would be to find a way to accomplish a follow-the-sun setup in PagerDuty without involving extra non-top-level schedules, but I haven't found a way to do that. (If someone knows, please clue me in).

The only other reasonable solution that I could think of was to update the `who's on call` command to ignore some schedules based on their names.  This is a general implementation which aims to make it so that the shared `getSchedules` function filters out any schedule names that contain the string `hidden`, which makes the behavior of this script consistent with regards to hidden schedules.

I checked PagerDuty, and no existing schedules (or escalation policies or services, for good measure) currently contain the string `hidden`, so this should not result in any existing schedules disappearing from the output of this command.

The only files that import `src/pagerduty.coffee` are `src/scripts/pagerduty.coffee` and the test script.

`getSchedules` is invoked by the following commands, which should all now exhibit the same behavior of ignoring schedules with `hidden` in the name:

```
pager schedules
am i on call
who's on call
```

I am not a coffeescript expert, nor am I certain that this is the best way to accomplish the goal. I would welcome any advice on this implementation, or on alternate ways to achieve the goal.

There don't appear to be any existing tests other than checking that string-patterns trigger commands to be invoked, which leaves me without any prior art to guide me as far as tests go.  I have not spent the time to figure out how to develop a proper test for this case.

I _did_ run my code through a `coffeescript -> javascript` transpiler and verify that I could run the javascript and it appeared to properly filter an array as intended.

<img width="1207" alt="screen shot 2018-08-23 at 11 23 09 am" src="https://user-images.githubusercontent.com/5838512/44541405-11139980-a6c7-11e8-89a2-0c58e54e95a4.png">

<img width="458" alt="screen shot 2018-08-23 at 11 23 33 am" src="https://user-images.githubusercontent.com/5838512/44541411-140e8a00-a6c7-11e8-87ff-c963aa8ede6a.png">

/cc @github/devcon for review
/cc @github/git-infrastructure for visibility