### PR TITLE
Revert "Ignore schedules with 'hidden' in the name."

### DIFF
--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -175,6 +175,4 @@ module.exports =
         cb(err)
         return
 
-      schedules = schedules.filter (x) -> x.indexOf("hidden") == -1
-
       cb(null, schedules)

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -1,5 +1,5 @@
 # Description:
-#   Interact with PagerDuty services, schedules, and incidents with Hubot.  Schedules with "hidden" in the name will be ignored.
+#   Interact with PagerDuty services, schedules, and incidents with Hubot.
 #
 # Commands:
 #   hubot pager me as <email> - remember your pager email is <email>


### PR DESCRIPTION
Reverts github/hubot-pager-me#15

As seen in [haystack](https://haystack.githubapp.com/hubot/needles/p9_FD1Uwxb4FvvvBLgvcpw) schedules is apparently not an array of _strings_.  It does appear to be an array, since `.filter` works, but `.indexOf` isn't a method on the items, so I suppose (at least one of) the members of the array are not strings.

This affected something @seveas was working on.  To be safe let's revert this PR.

@mistydemeo Is there some way I can test a different approach _outside_ of production?