### PR TITLE
Way to hide schedules (2nd attempt)

### DIFF
--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -175,4 +175,11 @@ module.exports =
         cb(err)
         return
 
+      # Remove any schedules with "hidden" in the name
+      schedules = schedules.filter (schedule) ->
+        if schedule.name?
+          return schedule.name.indexOf("hidden") == -1
+        else
+          return true
+
       cb(null, schedules)

--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -175,6 +175,4 @@ module.exports =
         cb(err)
         return
 
-      schedules = schedules.filter (x) -> x.indexOf("hidden") == -1
-
       cb(null, schedules)

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -1,5 +1,5 @@
 # Description:
-#   Interact with PagerDuty services, schedules, and incidents with Hubot.
+#   Interact with PagerDuty services, schedules, and incidents with Hubot.  Schedules with "hidden" in the name will be ignored.
 #
 # Commands:
 #   hubot pager me as <email> - remember your pager email is <email>

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -1,5 +1,5 @@
 # Description:
-#   Interact with PagerDuty services, schedules, and incidents with Hubot.  Schedules with "hidden" in the name will be ignored.
+#   Interact with PagerDuty services, schedules, and incidents with Hubot.
 #
 # Commands:
 #   hubot pager me as <email> - remember your pager email is <email>


### PR DESCRIPTION
#15 did not work because schedules are not strings, they are objects.  #16 reverts #15.

This pull request builds off of #16 and re-implements the same functionality, only (hopefully correctly) with the fact that schedule is an object with a name string attribute.  I inferred this from several places where `schedule` is used such as https://github.com/github/hubot-pager-me/blob/98d2f43a463c91c29c4cadd1542306221a04f549/src/scripts/pagerduty.coffee#L374

Here's my manual test of my new code given the object setup:

![image](https://user-images.githubusercontent.com/5838512/44923376-4b072000-ad05-11e8-9dec-b672049d013a.png)

![image](https://user-images.githubusercontent.com/5838512/44923392-58bca580-ad05-11e8-8d6e-ce72e700373f.png)

If this passes, then I'll update https://github.com/github/hubot-classic/pull/2817 with the results of this merge and try branch-deploying it.