### PR TITLE
Don't distract with canary alerts

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -104,6 +104,9 @@ module.exports = (robot) ->
         robot.emit 'error', err, msg
         return
 
+      incidents = incidents.filter (inc) ->
+         !/ninesapp\/canary/.test(inc.title)
+
       if incidents.length == 0
         msg.send "No open incidents"
         return


### PR DESCRIPTION
.pager sup no longer includes the canary alarms, to avoid distracting
people with them.