### PR TITLE
Improvements to `who's on call`

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -366,6 +366,8 @@ module.exports = (robot) ->
     if pagerduty.missingEnvironmentForApi(msg)
       return
 
+    msg.send "Retrieving schedules. This may take a few seconds..."
+
     pagerduty.getSchedules query, (err, schedules) ->
       if err?
         robot.emit 'error', err, msg
@@ -661,6 +663,8 @@ module.exports = (robot) ->
     if pagerduty.missingEnvironmentForApi(msg)
       return
 
+    msg.send "Retrieving schedules. This may take a few seconds..."
+
     scheduleName = msg.match[4]
 
     renderSchedule = (s, cb) ->
@@ -675,10 +679,8 @@ module.exports = (robot) ->
           return
 
         slackHandle = guessSlackHandleFromEmail(user)
-        url_start = "https://#{pagerduty.subdomain}.pagerduty.com"
-        contact_links = ["<#{url_start}/users/#{user.id}|PagerDuty>"]
-        contact_links.push(slackHandle) if slackHandle
-        cb(null, "• <#{url_start}/schedules##{schedule.id}|#{schedule.name}'s> oncall is #{user.name} (#{contact_links.join(' | ')})")
+        slackString = " (#{slackHandle})" if slackHandle
+        cb(null, "• <https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}|#{schedule.name}'s> oncall is #{user.name}#{slackString}")
 
     if scheduleName?
       withScheduleMatching msg, scheduleName, (s) ->
@@ -1142,8 +1144,8 @@ module.exports = (robot) ->
   guessSlackHandleFromEmail = (user) ->
     # Context: https://github.slack.com/archives/C0GNSSLUF/p1539181657000100
     if user.email == "jp@github.com"
-      "`@josh`"
+      "`josh`"
     else if user.email.search(/github\.com/)
-      user.email.replace(/(.+)\@github\.com/, '`@$1`')
+      user.email.replace(/(.+)\@github\.com/, '`$1`')
     else
       null

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -1112,12 +1112,12 @@ module.exports = (robot) ->
           schedules[scheduleId] = []
         if time not in schedules[scheduleId]
           schedules[scheduleId].push time
-          buffer += "• #{time} #{username} (<#{oncall.schedule.html_url}>|#{oncall.schedule.summary})\n"
+          buffer += "• #{time} #{username} (<#{oncall.schedule.html_url}|#{oncall.schedule.summary}>)\n"
       else if oncall.escalation_policy?
         # no schedule embedded
         epSummary = oncall.escalation_policy.summary
         epURL = oncall.escalation_policy.html_url
-        buffer += "• #{time} #{username} (<#{epURL}>|#{epSummary})\n"
+        buffer += "• #{time} #{username} (<#{epURL}|#{epSummary}>)\n"
       else 
         # override
         buffer += "• #{time} #{username}\n"

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -665,7 +665,7 @@ module.exports = (robot) ->
           return
 
         Scrolls.log("info", {at: 'who-is-on-call/renderSchedule', schedule: schedule.name, username: username})
-        if !pagerEnabledForScheduleOrEscalation(schedule) || username == "hubot"
+        if !pagerEnabledForScheduleOrEscalation(schedule) || username == "hubot" || username == undefined
           cb(null, undefined)
           return
 

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -1142,8 +1142,8 @@ module.exports = (robot) ->
   guessSlackHandleFromEmail = (user) ->
     # Context: https://github.slack.com/archives/C0GNSSLUF/p1539181657000100
     if user.email == "jp@github.com"
-      "@josh"
+      "`@josh`"
     else if user.email.search(/github\.com/)
-      user.email.replace(/(.+)\@github\.com/, '@$1')
+      user.email.replace(/(.+)\@github\.com/, '`@$1`')
     else
       null

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -698,7 +698,8 @@ module.exports = (robot) ->
 
         results = (result for result in results when result?)
         Scrolls.log("info", {at: 'who-is-on-call/map-schedules'})
-        msg.send results.join("\n")
+        for chunk in chunkMessageLines(results, 7000)
+          msg.send chunk.join("\n")
 
   # hubot pager services - list services
   robot.respond /(pager|major)( me)? services$/i, (msg) ->
@@ -1110,3 +1111,21 @@ module.exports = (robot) ->
         # override
         buffer += "* #{time} #{username}\n"
     buffer
+
+
+  chunkMessageLines = (messageLines, boundary) ->
+    allChunks = []
+    thisChunk = []
+    charCount = 0
+
+    for line in messageLines
+      if charCount >= boundary
+        allChunks.push(thisChunk)
+        charCount = 0
+        thisChunk = []
+
+      thisChunk.push(line)
+      charCount += line.length
+
+    allChunks.push(thisChunk)
+    allChunks

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -376,13 +376,15 @@ module.exports = (robot) ->
         return
 
       renderSchedule = (schedule, cb) ->
-        cb(null, "* #{schedule.name} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}")
+        cb(null, "• <https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}|#{schedule.name}>")
 
       async.map schedules, renderSchedule, (err, results) ->
         if err?
           robot.emit 'error', err, msg
           return
-        msg.send results.join("\n")
+
+        for chunk in chunkMessageLines(results, 7000)
+          msg.send chunk.join("\n")
 
   # hubot pager schedule <schedule> - show <schedule>'s shifts for the upcoming month
   # hubot pager overrides <schedule> - show upcoming overrides for the next month

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -426,7 +426,7 @@ module.exports = (robot) ->
           robot.emit 'error', err, msg
           return
 
-        unless entries
+        unless entries.length > 0
           msg.send "None found!"
           return
 

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -659,7 +659,7 @@ module.exports = (robot) ->
     scheduleName = msg.match[4]
 
     renderSchedule = (s, cb) ->
-      withCurrentOncall msg, s, (err, username, schedule) ->
+      withCurrentOncallId msg, s, (err, userId, username, schedule) ->
         if err?
           cb(err)
           return
@@ -669,7 +669,8 @@ module.exports = (robot) ->
           cb(null, undefined)
           return
 
-        cb(null, "* #{schedule.name}'s oncall is #{username} - https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}")
+        url_start = "https://#{pagerduty.subdomain}.pagerduty.com"
+        cb(null, "• <#{url_start}/schedules##{schedule.id}|#{schedule.name}'s> oncall is <#{url_start}/users/#{userId}|#{username}>")
 
     if scheduleName?
       withScheduleMatching msg, scheduleName, (s) ->


### PR DESCRIPTION
Several notable improvements to the `who's on call` command:

- We no longer display schedules where no user is on-call (by filtering out any undefined usernames)
- We display a slightly nicer output: prettier links, better bullet points, and a link to the user on-call
- Chunk responses so that slack no longer truncates after around 8000 characters (We chunk at 7000 characters, for a wide margin of safety re: newlines).