### PR TITLE
Filter users to match email precisely

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -828,10 +828,18 @@ module.exports = (robot) ->
           cb null
           return
         else
-          msg.send "Sorry, I expected to get 1 user back for #{email}, but got #{json.users.length} :sweat:. Can you make sure that is actually a real user on PagerDuty?"
-          return
+          user = tryToFind(email, json.users)
+          if !user
+            msg.send "Sorry, I expected to get 1 user back for #{email}, but only found a list that didn't include the requested email :sweat:. Can you make sure that is actually a real user on PagerDuty?"
+            return
+          else
+            cb(user)
 
       cb(json.users[0])
+
+  tryToFind = (email, users) ->
+    users.find (user) ->
+      user.email == email
 
   oneScheduleMatching = (msg, q, cb) ->
     query = {

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -831,9 +831,9 @@ module.exports = (robot) ->
           user = tryToFind(email, json.users)
           if !user
             msg.send "Sorry, I expected to get 1 user back for #{email}, but only found a list that didn't include the requested email :sweat:. Can you make sure that is actually a real user on PagerDuty?"
-            return
           else
             cb(user)
+          return
 
       cb(json.users[0])
 


### PR DESCRIPTION
Since user matching is done fuzzily, we might get multiple results for certain emails. Instead of immediately bailing it, let's check for an exact match before giving up.