### PR TITLE
Show non-api-related pagerduty schedule errors to the user

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -160,6 +160,12 @@ module.exports = (robot) ->
       reassignmentParametersForUserOrScheduleOrEscalationPolicy msg, query, (err, results) ->
         if err?
           robot.emit 'error', err, msg
+
+          # reassignmentParametersForUserOrScheduleOrEscalationPolicy constructs explicit,
+          # human-consumable errors with good messages. Send it to the user if we got one.
+          if err.message != ""
+            msg.reply err.message
+
           return
 
         pagerDutyIntegrationAPI msg, "trigger", query, description, severity, (err, json) ->


### PR DESCRIPTION
If you try to page a non-existent schedule, or the schedule is marked
'#nopage', or something - the callback spaghetti actually generates a
decent error here. Rather than just spitting out to haystack, we could
send it to the user, and this PR does just that.

Other places in the script do not explicitly construct `new Error()`s,
so I didn't bother working on that. This script is difficult to follow
and I'm hesitant to make broader changes on a whim.