### PR TITLE
Ignore prometheus canaries too by default

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -107,7 +107,7 @@ module.exports = (robot) ->
 
       unless msg.match[4]
         incidents = incidents.filter (inc) ->
-           !/ninesapp\/canary/.test(inc.title)
+           !/(ninesapp\/|Prometheus )canary/.test(inc.title)
 
       if incidents.length == 0
         msg.send "No open incidents"


### PR DESCRIPTION
We have more canaries, let's not distract people with these either.