### PR TITLE
Let pager assign to service of the escalation directly than to hubot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-pager-me",
   "description": "PagerDuty integration for Hubot ",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "author": "Josh Nichols <technicalpickles@github.com>",
   "license": "MIT",
   "keywords": [

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -178,13 +178,14 @@ module.exports = (robot) ->
                 "type": "incident",
                 "title": "#{description}",
                 "urgency": "high",
+                "severity": "#{severity}",
                 "escalation_policy": {
                   "id": "#{results.escalation_policy}",
                   "type": "escalation_policy_reference"
-                },
+                  },
                 "service": results.service
-            }
-          }
+                }
+            }   
 
           pagerduty.post "/incidents", data, headers, (err, json) ->
             if err?
@@ -928,7 +929,8 @@ module.exports = (robot) ->
             return
 
           result = escalation_policy: escalationPolicy.id, name: escalationPolicy.name
-          if escalationPolicy.services?.length > 0
+          if escalationPolicy.services?.length == 1
+            # We pick the service only if it's not ambigious
             result.service = escalationPolicy.services[0]
           cb(null, result)
           return

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -192,7 +192,6 @@ module.exports = (robot) ->
                 }
             }   
 
-          console.log(data)
           pagerduty.post "/incidents", data, headers, (err, json) ->
             if err?
               robot.emit 'error', err, msg

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -168,7 +168,7 @@ module.exports = (robot) ->
 
           return
 
-        headers = {from: triggeredByPagerDutyUserEmail}        
+        headers = {from: triggeredByPagerDutyUserEmail}
 
         if results.service?
           # If we know the service, create incident directly with it...

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -168,17 +168,22 @@ module.exports = (robot) ->
 
           return
 
-        headers = {from: triggeredByPagerDutyUserEmail}
+        headers = {from: triggeredByPagerDutyUserEmail}        
 
         if results.service?
           # If we know the service, create incident directly with it...
           # See https://api-reference.pagerduty.com/#!/Incidents/post_incidents
+
+          urgency = "high"
+          # There isn't a way to set severity from this API, so map those to urgencies
+          if severity in ['warning', 'info']
+            urgency = "low"
+
           data = {
             "incident": {
                 "type": "incident",
                 "title": "#{description}",
-                "urgency": "high",
-                "severity": "#{severity}",
+                "urgency": "#{urgency}",
                 "escalation_policy": {
                   "id": "#{results.escalation_policy}",
                   "type": "escalation_policy_reference"
@@ -187,6 +192,7 @@ module.exports = (robot) ->
                 }
             }   
 
+          console.log(data)
           pagerduty.post "/incidents", data, headers, (err, json) ->
             if err?
               robot.emit 'error', err, msg


### PR DESCRIPTION
https://github.com/github/hubot-classic/issues/3258
This makes https://www.pagerduty.com/docs/guides/slack-integration-guide/ possible!

So, looks like we trigger an event to create an incident with service key of hubot (so..all incidents are created against hubot service), then we update the incident with escalation policy.
What I am trying to accomplish is to make sure incident is created against our service (so slack integration works well!)
The way it is, we can't update the service once the incident is created.
I can use https://api-reference.pagerduty.com/#!/Incidents/post_incidents to create incident directly with specified service, which works well.

the state our team (`pe-actions-core`) is in now, most of alerts would be manual, so getting updates in a slack channel is crucial , this PR makes it possible
once we integrate into github, nines app alerting stuff will tc of that.