### PR TITLE
Reduce API load when showing list of schedules

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -704,7 +704,7 @@ module.exports = (robot) ->
           msg.send text
       return
     else
-      msg.send "Due to rate limiting please include the schedule name to see who's on call"
+      msg.send "Due to rate limiting please include the schedule name to see who's on call. E.g. who's on call for <schedule>"
 
     pagerduty.getSchedules (err, schedules) ->
       if err?

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -704,7 +704,7 @@ module.exports = (robot) ->
           msg.send text
       return
     else
-      msg.send "Due to rate limiting please include the schedule name to see who's on call. E.g. who's on call for <schedule>"
+      msg.send "Due to rate limiting please include the schedule name to also see who's on call. E.g. `.who's on call for <schedule>`. Schedule names are being retrieved..."
 
     pagerduty.getSchedules (err, schedules) ->
       if err?

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -240,11 +240,11 @@ module.exports = (robot) ->
 
       email  = emailForUser(hubotUser)
       incidentsForEmail incidents, email, (err, filteredIncidents) ->
-        if err? 
-          msg.send err.message 
+        if err?
+          msg.send err.message
           return
-        
-        if force 
+
+        if force
           filteredIncidents = incidents
 
         if filteredIncidents.length is 0
@@ -286,16 +286,16 @@ module.exports = (robot) ->
       if err?
         robot.emit 'error', err, msg
         return
-      
+
       email  = emailForUser(hubotUser)
       incidentsForEmail incidents, email, (err, filteredIncidents) ->
-        if err? 
+        if err?
           robot.emit 'error', err, msg
           return
 
-        if force 
+        if force
           filteredIncidents = incidents
-        
+
         if filteredIncidents.length is 0
           # nothing assigned to the user, but there were others
           if incidents.length > 0 and not force
@@ -325,7 +325,7 @@ module.exports = (robot) ->
       buffer = ""
       for note in json.notes
         buffer += "#{note.created_at} #{note.user.summary}: #{note.content}\n"
-      if not buffer 
+      if not buffer
         buffer = "No notes!"
       msg.send buffer
 
@@ -403,7 +403,7 @@ module.exports = (robot) ->
       since: moment().format(),
       until: moment().add(30, 'days').format()
     }
-      
+
     if !msg.match[5]
       msg.reply "Please specify a schedule with 'pager #{msg.match[3]} <name>.'' Use 'pager schedules' to list all schedules."
       return
@@ -458,7 +458,7 @@ module.exports = (robot) ->
         timezone = msg.match[4]
       else
         timezone = 'UTC'
-        
+
       query = {
         since: moment().format(),
         until: moment().add(30, 'days').format(),
@@ -580,7 +580,7 @@ module.exports = (robot) ->
         override  = {
           'start': start,
           'end':   end,
-          'user':  { 
+          'user':  {
             'id':   userId,
             "type": "user_reference",
           },
@@ -606,7 +606,7 @@ module.exports = (robot) ->
               if err?
                 robot.emit 'error', err, msg
                 return
-              
+
               msg.send "Rejoice, @#{old_username}! @#{user.name} has the pager on #{schedule.name} until #{end.format()}"
 
   # hubot Am I on call - return if I'm currently on call or not
@@ -624,8 +624,8 @@ module.exports = (robot) ->
       renderSchedule = (s, cb) ->
         if not memberOfSchedule(s, userId)
           cb(null, {member: false})
-          return 
-        
+          return
+
         withCurrentOncallId msg, s, (err, oncallUserid, oncallUsername, schedule) ->
           if err?
             cb(err)
@@ -648,7 +648,7 @@ module.exports = (robot) ->
         if schedules.length == 0
           msg.send 'No schedules found!'
           return
-        
+
         if (schedules.every (s) -> not memberOfSchedule(s, userId))
           msg.send "You are not assigned to any schedules"
           return
@@ -686,7 +686,7 @@ module.exports = (robot) ->
         slackHandle = guessSlackHandleFromEmail(user)
         slackString = " (#{slackHandle})" if slackHandle
         cb(null, "• <https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}|#{schedule.name}'s> oncall is #{user.name}#{slackString}")
-    
+
     renderScheduleNoUser = (s, cb) ->
       Scrolls.log("info", {at: 'who-is-on-call/renderSchedule', schedule: s.name})
       if !pagerEnabledForScheduleOrEscalation(s)
@@ -694,7 +694,7 @@ module.exports = (robot) ->
         return
 
       cb(null, "• <https://#{pagerduty.subdomain}.pagerduty.com/schedules##{s.id}|#{s.name}>")
-    
+
     if scheduleName?
       withScheduleMatching msg, scheduleName, (s) ->
         renderSchedule s, (err, text) ->
@@ -704,7 +704,7 @@ module.exports = (robot) ->
           msg.send text
       return
     else
-      msg.send "Due to rate limiting please include the schedule/escalation policy name to see who's on call"
+      msg.send "Due to rate limiting please include the schedule name to see who's on call"
 
     pagerduty.getSchedules (err, schedules) ->
       if err?
@@ -1019,7 +1019,7 @@ module.exports = (robot) ->
                 inc.trigger_summary_data.description
               else
                 ""
-            else 
+            else
               "#{inc.title} #{inc.summary}"
 
     names = []
@@ -1028,9 +1028,9 @@ module.exports = (robot) ->
 
     if names
       assigned_to = "- assigned to #{names.join(",")}"
-    else 
+    else
       assigned_to = "- nobody currently assigned"
-    
+
     "#{inc.incident_number}: #{inc.created_at} #{summary} #{assigned_to}\n"
 
   updateIncidents = (msg, incidentNumbers, statusFilter, updatedStatus) ->
@@ -1105,10 +1105,10 @@ module.exports = (robot) ->
 
   incidentsForEmail = (incidents, userEmail, cb) ->
     allUserEmails (err, userEmails) ->
-      if err? 
+      if err?
         cb(err)
-        return 
-      
+        return
+
       filtered = []
       for incident in incidents
         for assignment in incident.assignments
@@ -1124,14 +1124,14 @@ module.exports = (robot) ->
   formatOncalls = (oncalls, timezone) ->
     buffer = ""
     schedules = {}
-    for oncall in oncalls 
+    for oncall in oncalls
       startTime = moment(oncall.start).tz(timezone).format()
       endTime   = moment(oncall.end).tz(timezone).format()
       time      = "#{startTime} - #{endTime}"
       username  = guessSlackHandleFromEmail(oncall.user) || oncall.user.summary
       if oncall.schedule?
         scheduleId = oncall.schedule.id
-        if scheduleId not of schedules 
+        if scheduleId not of schedules
           schedules[scheduleId] = []
         if time not in schedules[scheduleId]
           schedules[scheduleId].push time
@@ -1141,7 +1141,7 @@ module.exports = (robot) ->
         epSummary = oncall.escalation_policy.summary
         epURL = oncall.escalation_policy.html_url
         buffer += "• #{time} #{username} (<#{epURL}|#{epSummary}>)\n"
-      else 
+      else
         # override
         buffer += "• #{time} #{username}\n"
     buffer


### PR DESCRIPTION
## Summary 
`who's on call` currently requires several API requests:
- Obtain all schedules
- For each schedule find who's on call
- Load the PagerDuty user profile for the found user

When not provided with an argument it'll load all schedules (~200 at the moment). This ends up being around 401 API requests each time that chatop is run, which can be quite frequent during an incident.

We currently have a 2000 req/min API rate limit on our entire PagerDuty account. With other API tokens, such as nines and observability-observer also causing traffic, we've recently run into this chatop [failing](https://haystack.githubapp.com/hubot/rollups/364e6a3e83001b220729c8d640c0b6cf) due to rate limiting.

After this PR users can still list all the schedules we have in PagerDuty to figure out which name best matches what they are looking for. Following this they'll need to run the chatop again but provide a schedule name to show who's on call for that schedule. Appropriate messaging has been added for user awareness. 

## Before

> Hubot> hubot who's on call
Hubot> script="pagerduty" at="get/request" path="/schedules" query="{ offset: 0, limit: 100 }" level="info"
Retrieving schedules. This may take a few seconds...
• <https://github-development.pagerduty.com/schedules#PWC6XR2|demo's> oncall is kittens (`antonio.santos`)
• <https://github-development.pagerduty.com/schedules#P5JTAZB|hubot's> oncall is stephanmiehe (`stephanmiehe`)
• <https://github-development.pagerduty.com/schedules#PQAUEEL|jamie-hubot's> oncall is someone (`someone`)
• <https://github-development.pagerduty.com/schedules#P2A9XCL|ninesapp-canary's> oncall is kittens (`antonio.santos`)
• <https://github-development.pagerduty.com/schedules#P0K6B1K|physical-infrastructure's> oncall is kittens (`antonio.santos`)
• <https://github-development.pagerduty.com/schedules#P3FVKWF|test's> oncall is stephanmiehe (`stephanmiehe`)

> Hubot> hubot who's on call jamie-hubot
Retrieving schedules. This may take a few seconds...
• <https://github-development.pagerduty.com/schedules#PQAUEEL|jamie-hubot's> oncall is kittens (`antonio.santos`)

## After

> Hubot> hubot who's on call
Retrieving schedules. This may take a few seconds...
Due to rate limiting please include the schedule name to see who's on call
• <https://github-development.pagerduty.com/schedules#PWC6XR2|demo>
• <https://github-development.pagerduty.com/schedules#P5JTAZB|hubot>
• <https://github-development.pagerduty.com/schedules#PQAUEEL|jamie-hubot>
• <https://github-development.pagerduty.com/schedules#P2A9XCL|ninesapp-canary>
• <https://github-development.pagerduty.com/schedules#P0K6B1K|physical-infrastructure>
• <https://github-development.pagerduty.com/schedules#P3FVKWF|test>

> Hubot> hubot who's on call jamie-hubot
Retrieving schedules. This may take a few seconds...
• <https://github-development.pagerduty.com/schedules#PQAUEEL|jamie-hubot's> oncall is kittens (`antonio.santos`)

/cc https://github.com/github/hubot-classic/issues/3370