### PR TITLE
Add damerauLevenshtein matching to pager schedule queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "coffee-script": "~1.6",
     "moment-timezone": "~0.4.0",
     "request": "^2.83.0",
-    "query-string": "^5.0.1"
+    "query-string": "^5.0.1",
+    "talisman": "^0.21.0"
   },
   "devDependencies": {
     "chai": "^2.1.1",

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -49,7 +49,7 @@ pagerDutyUserEmail     = process.env.HUBOT_PAGERDUTY_USERNAME
 pagerDutyServiceApiKey = process.env.HUBOT_PAGERDUTY_SERVICE_API_KEY
 pagerDutyEventsAPIURL  = 'https://events.pagerduty.com/v2/enqueue'
 
-damerauLevenshtein = require('talisman/metrics/distance/damerau-levenshtein'
+damerauLevenshtein = require('talisman/metrics/distance/damerau-levenshtein')
 
 module.exports = (robot) ->
 

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -886,7 +886,7 @@ module.exports = (robot) ->
           else
             return 0
 
-        results = results.slice(0, 4).map -> (s)
+        results = results.slice(0, 4).map (s) ->
           # s[0] = damerauLevenshtein score
           # s[1] = actual schedule
           return s[1]


### PR DESCRIPTION
It's often the case that people have transposed a character or two when
querying hubot for pager information. We can make that slightly easier
on them by employing a variant of the Levenshtein distance algorithm
that takes into account transpositions (in addition to other spelling
mistakes).

Then, if we don't get an exact match, we can at least return a list of
suggestions.