### PR TITLE
@mention people in slack when they are searched for

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -1187,10 +1187,7 @@ module.exports = (robot) ->
     allChunks
 
   guessSlackHandleFromEmail = (user) ->
-    # Context: https://github.slack.com/archives/C0GNSSLUF/p1539181657000100
-    if user.email == "jp@github.com"
-      "`josh`"
-    else if user.email.search(/github\.com/)
+    if user.email.search(/github\.com/)
       user.email.replace(/(.+)\@github\.com/, '`$1`')
     else
       null

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -707,7 +707,7 @@ module.exports = (robot) ->
 
         slackHandle = guessSlackHandleFromEmail(user)
         slackString = " (#{slackHandle})" if slackHandle
-        cb(null, "• <https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}|#{schedule.name}'s> oncall is #{user.name}#{slackString}")
+        cb(null, "• <https://#{pagerduty.subdomain}.pagerduty.com/schedules##{schedule.id}|#{schedule.name}'s> oncall is @#{user.name} #{slackString}")
 
     renderScheduleNoUser = (s, cb) ->
       Scrolls.log("info", {at: 'who-is-on-call/renderSchedule', schedule: s.name})


### PR DESCRIPTION
- remove what looks like an old hack
- @-mention people when they are searched for with `.whos oncall`

It seems like we should mention people when they're searched for, because the most common usecase is that someone is looking at who's oncall before tagging them or paging them.

⚠️ this is currently untested, I need to figure out how to test it. But interested in your thoughts!