### PR TITLE
trim at symbol from names

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -135,7 +135,11 @@ module.exports = (robot) ->
     if pagerduty.missingEnvironmentForApi(msg)
       return
 
-    hubotUser = robot.getUserBySlackUser(msg.message.user)
+    user = msg.message.user
+    if user[0] == "@"
+      user = user.slice(1)
+
+    hubotUser = robot.getUserBySlackUser(user)
     fromUserName   = hubotUser.name
     query          = msg.match[3]
     severity       = msg.match[5]
@@ -691,7 +695,7 @@ module.exports = (robot) ->
       return
 
     msg.send "Retrieving schedules. This may take a few seconds..."
-    
+
     renderSchedule = (s, cb) ->
       withCurrentOncallUser msg, s, (err, user, schedule) ->
         if err?
@@ -951,7 +955,7 @@ module.exports = (robot) ->
       else if schedules.length == 0
         msg.send "No results"
         return
-      else    
+      else
         cb(schedules)
 
   reassignmentParametersForUserOrScheduleOrEscalationPolicy = (msg, string, cb) ->


### PR DESCRIPTION
hubot has some trouble looking up slack users with an @ symbol
<img width="535" alt="152260350-5a677f1e-6f49-44ae-8b12-13de827e41d4" src="https://user-images.githubusercontent.com/1149246/153227221-bee2f2af-00a1-4a77-acc7-c0c95c87aefc.png">


It works fine without the @ symbol
<img width="384" alt="152260405-c3f21033-d8dd-4d28-b81b-44e5c2d6787a" src="https://user-images.githubusercontent.com/1149246/153227277-d02598d5-b467-4ace-b32a-3c2696446927.png">


This isn't a big deal, but was surprising behavior. In this case I found this issue trying to trigger a pager test, it would be good to make that as reliable as possible for use in a real emergency.

I'm not really sure how to verify that this works without a deploy. I tested the JS itself.