### PR TITLE
Allow paging incident commanders again

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -150,28 +150,6 @@ module.exports = (robot) ->
       msg.send "Please include a reason for paging, like 'hubot pager @username THE SKY IS FALLING!'."
       return
 
-    # Deprecate incident commanders
-    if query == "incident-commander"
-      deprecation_msg =  """
-      The incident commander rotation has been deprecated in favour of decentralized incident management. Please consider paging one of the following teams:
-
-      |=====================================================================================================|
-      | Product                         | Catalog Entry        | Pager                                      |
-      |=================================|======================|============================================|
-      | Git Operations                  | git-protocols        | `.pager trigger git-systems`               |
-      | API Requests                    | github/api           | `.pager trigger github-dotcom-oncall`      |
-      | Webhooks                        | github/webhooks      | `.pager trirger github-dotcom-oncall`      |
-      | Issues, Pull Requests, Projects | github/issues        | `.pager trigger github-dotcom-oncall`      |
-      |                                 | github/projects      | `.pager trigger github-dotcom-oncall`      |
-      |                                 | github/pull-requests | `.pager trigger github-dotcom-oncall`      |
-      | GitHub Actions                  | actions              | `.pager trigger actions-experience-oncall` |
-      | GitHub Packages                 | registry             | `.pager trigger packages`   |
-      | GitHub Pages                    | pages                | `.pager trigger pages`                     |
-      |=====================================================================================================|
-      """
-      msg.send deprecation_msg
-      return
-
     # Figure out who we are
     campfireUserToPagerDutyUser msg, hubotUser, false, (triggeredByPagerDutyUser) ->
       triggeredByPagerDutyUserEmail = if triggeredByPagerDutyUser?


### PR DESCRIPTION
Per [Slack](https://github.slack.com/archives/C1AH2A4R2/p1663027441618309?thread_ts=1663027397.190869&cid=C1AH2A4R2), this message is outdated and is no longer accurate. We should allow paging the incident commander rotation again.

After this is is merged, we'll have to bump the sha in hubot-classic.