### PR TITLE
fix sentry pagerduty schedule undefined exception

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -1041,7 +1041,7 @@ module.exports = (robot) ->
         return
 
       unless oncalls and oncalls.length > 0
-        cb(null, "nobody", schedule)
+        cb(null, "nobody", schedules)
         return
 
       # Because we can have multiple oncalls for a schedule (due to escalation policies),


### PR DESCRIPTION
fixes [sentry](https://sentry.io/organizations/github/issues/2775868208/?environment=production_v2&project=1821026&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h) exception
`ReferenceError: schedule is not defined`
