### PR TITLE
Update who's on call to query escalations when no users match a schedule

### DIFF
--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -183,3 +183,16 @@ module.exports =
           return true
 
       cb(null, schedules)
+  
+  getEscalationPolicies: (query, cb) ->
+    if typeof(query) is 'function'
+      cb = query
+      query = {}
+
+    @getAll "/escalation_policies", query, "escalation_policies", (err, escalation_policies) ->
+      if err?
+        cb(err)
+        return
+
+      cb(null, escalation_policies)
+


### PR DESCRIPTION
Our team's escalation policy is currently comprised of schedules from two different teams that belong to separate namespaces. The schedules implement a follow the sun rotation, so oftentimes asking `.who is on call [query]` will yield no results, even when there is somebody on call for the escalation policy who would be paged via `.pager trigger`.

The proposal here is to look for an escalation policy that exactly matches a query string in the event that no on call users are found for the matching schedules. If there is an escalation policy tied to an on call user, display that via messaging. If no escalation policy is found or if no user is on call for the policy, display the original "No human is on call for [schedule x]" message.

Some of this code could be refactored for reusability, but I was hesitant to change too much here given the lack of testing for these areas.