### PR TITLE
Ensure user with lowest escalation is returned from whois

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -1126,7 +1126,10 @@ module.exports = (robot) ->
         cb(null, "nobody", escalation_policy)
         return
 
-      userId = oncalls[0].user.id
+      sortedOncalls = oncalls.sort (a, b) ->
+        a.escalation_level - b.escalation_level
+
+      userId = sortedOncalls[0].user.id
       getPagerDutyUser userId, (err, user) ->
         if err?
           cb(err)


### PR DESCRIPTION
Small addendum to https://github.com/github/hubot-pager-me/pull/53

When crawling up the escalation policy in the event that no users are on call for a schedule invoked with `.who is on call.`, make sure that the user with the lowest escalation level is returned. Currently this just returns the first oncall that is found in the response, which isn't necessarily who would be paged.