### PR TITLE
Fix escalation policy length check in `.who is` command

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -985,7 +985,7 @@ module.exports = (robot) ->
         return
 
       # Single result returned
-      if escalation_policies?.length = 1
+      if escalation_policies?.length == 1
         escalation_policy = escalation_policies[0]
 
       # Multiple results returned and one is exact (case-insensitive)


### PR DESCRIPTION
Addendum to https://github.com/github/hubot-pager-me/pull/53, which supports looking up oncalls for an escalation policy in the event that no oncalls are found for a schedule

In the current state, so long as escalation policies are defined for a schedule, this always returns the first match rather than an exact match. This change ensures that we instead look for a directly matching policy. 

Fixes https://github.com/github/hubot-classic/issues/4789