### PR TITLE
Get the newest incidents rather than the oldest.

### DIFF
--- a/src/pagerduty.coffee
+++ b/src/pagerduty.coffee
@@ -157,7 +157,7 @@ module.exports =
   getIncidents: (statuses, cb) ->
     query =
       statuses:  statuses.split ","
-      sort_by: "incident_number:asc"
+      sort_by: "incident_number:desc"
     @get "/incidents", query, (err, json) ->
       if err?
         cb(err)
@@ -195,4 +195,3 @@ module.exports =
         return
 
       cb(null, escalation_policies)
-


### PR DESCRIPTION
Currently many `.pager` chatops are not working for us (such as `.pager ack`) because we have too many open incidents to find them all.

We could implement pagination for the API, but that would make all the chatops slower and continue to encourage the anti-pattern of having obscene numbers of open incidents.

Instead, I think we should just change the order we get incidents in so that we only get the newest incidents. This means when you `.pager ack` it's way more likely that the incident you are trying to ack will be found.