### PR TITLE
Prompt user to use /pd trigger when paging the Deploys team

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -174,9 +174,11 @@ module.exports = (robot) ->
           return
 
         pagerDutyIntegrationAPI msg, "trigger", query, description, severity, (err, json) ->
-
           if err?
             robot.emit 'error', err, msg
+            return
+          if query == "Deploys Team" || "deploys"
+            msg.reply "Please use the '/pd trigger' command in Slack to page the Deploys team."
             return
 
           msg.reply ":pager: triggered! now assigning it to the right user..."


### PR DESCRIPTION
The normal `.pager trigger` chatop does not Trigger the notification in Slack. Our team is exploring this option as we want to allow teammates who are in other timezones to be able to intercept pages if it's in the middle of the night for the on call person. Making this change would allow us to do so because the `/pd trigger` Slack command does trigger the page notification in Slack. 

Related Issues:
https://github.com/github/deploys/issues/1511
https://github.com/github/delivery-org/issues/3357