### PR TITLE
Update pagerduty.coffee

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -608,7 +608,7 @@ module.exports = (robot) ->
                 robot.emit 'error', err, msg
                 return
 
-              msg.send "Rejoice, @#{old_username}! @#{user.name} has the pager on #{schedule.name} until #{end.format()}"
+              msg.send "Rejoice, `@#{old_username}`! @#{user.name} has the pager on #{schedule.name} until #{end.format()}"
 
   # hubot Am I on call - return if I'm currently on call or not
   robot.respond /am i on (call|oncall|on-call)/i, (msg) ->

--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -608,7 +608,7 @@ module.exports = (robot) ->
                 robot.emit 'error', err, msg
                 return
 
-              msg.send "Rejoice, `@#{old_username}`! @#{user.name} has the pager on #{schedule.name} until #{end.format()}"
+              msg.send "Rejoice, `#{old_username}`! @#{user.name} has the pager on #{schedule.name} until #{end.format()}"
 
   # hubot Am I on call - return if I'm currently on call or not
   robot.respond /am i on (call|oncall|on-call)/i, (msg) ->


### PR DESCRIPTION
Proposing to hide the @old_username inside `code` ticks for slack messages.
Often times, `.pager me team` is used to take load off a fatigued teammate, or after-hours to prevent them from getting noise. @'ing that person kind of defeats those purposes.